### PR TITLE
Added missing "createCase" operation in CollaborationService CODAP listener

### DIFF
--- a/CollaborationService/js/CollaborationService.js
+++ b/CollaborationService/js/CollaborationService.js
@@ -243,6 +243,7 @@ var dataManager = Object.create({
         firebaseKeyValue = _case.values[collaborationCollection.firebaseKey];
 
         switch (operation) {
+          case 'createCase':
           case 'createCases':
             if (!firebaseKeyValue) {
               pushRef = collaborationCollection.casesRef.push();


### PR DESCRIPTION
It was only listening for "createCases" so it missed the insert of the parent case since it was a single case.  This caused a cascading failure as the Firebase key was not set in the parent case before it was referenced in the child cases.