### PR TITLE
Sampler improvements

### DIFF
--- a/TP-Sampler/src/app.js
+++ b/TP-Sampler/src/app.js
@@ -293,7 +293,8 @@ function(Snap, CodapCom, View, ui, utils) {
   function resetButtonPressed() {
     this.blur();
     experimentNumber = 0;
-    codapCom.deleteAll(device, ui.populateContextsList(caseVariables, view, codapCom));
+    codapCom.deleteAll();
+    codapCom.deleteAllAttributes(device, ui.populateContextsList(caseVariables, view, codapCom));
     codapCom.logAction("clearData:");
   }
 

--- a/TP-Sampler/src/app.js
+++ b/TP-Sampler/src/app.js
@@ -58,7 +58,9 @@ function(Snap, CodapCom, View, ui, utils) {
         withReplacement: withReplacement,
         hidden: hidden,
         password: password,
-        dataSetName: dataSetName
+        dataSetName: dataSetName,
+        attrNames: codapCom.attrNames,
+        attrIds: codapCom.attrIds
       }
     };
   }
@@ -84,6 +86,10 @@ function(Snap, CodapCom, View, ui, utils) {
       ui.render(hidden, password, false, withReplacement, device);
       if (isCollector) {
         refreshCaseList();
+      }
+      if (state.attrNames) {
+        codapCom.attrNames = state.attrNames;
+        codapCom.attrIds = state.attrIds;
       }
     }
     view.render();

--- a/TP-Sampler/src/app.js
+++ b/TP-Sampler/src/app.js
@@ -354,18 +354,27 @@ function(Snap, CodapCom, View, ui, utils) {
     }
 
     function selectNext() {
-      var timeout = (speed === kFastestSpeed) ? 0 :
+      var timeout = device === "spinner" ? 1 :
+          (speed === kFastestSpeed) ? 0 :
           // Give "Fast" a little extra
-          (speed === kFastestSpeed - 1 ? 1000 / kFastestSpeed :
-              1000 / speed);
+          (speed === kFastestSpeed - 1 ? 600 / kFastestSpeed :
+              600 / speed);
       if (!paused) {
         if (speed !== kFastestSpeed) {
           if (sequence[runNumber][draw] === "EMPTY") {
             // jump to the end. Slots will push out automatically.
             draw = sequence[runNumber].length - 1;
           }
-          view.animateSelectNextVariable(sequence[runNumber][draw], draw,
-              addNextSequenceRunToCODAP);
+          function selectionMade() {
+            if (running) {
+              if (sequence[runNumber]) {
+                setTimeout(selectNext, timeout);
+              } else {
+                setTimeout(view.endAnimation, timeout);
+              }
+            }
+          }
+          view.animateSelectNextVariable(sequence[runNumber][draw], draw, selectionMade, addNextSequenceRunToCODAP);
 
           if (draw < sequence[runNumber].length - 1) {
             draw++;
@@ -378,13 +387,7 @@ function(Snap, CodapCom, View, ui, utils) {
           return;
         }
       }
-      if (running) {
-        if (sequence[runNumber]) {
-          setTimeout(selectNext, timeout);
-        } else {
-          setTimeout(view.endAnimation, timeout);
-        }
-      }
+
       // console.log('speed: ' + speed + ', timeout: ' + timeout + ', draw: ' + draw + ', runNumber: ' + runNumber);
     }
 

--- a/TP-Sampler/src/app.js
+++ b/TP-Sampler/src/app.js
@@ -294,7 +294,10 @@ function(Snap, CodapCom, View, ui, utils) {
     this.blur();
     experimentNumber = 0;
     codapCom.deleteAll();
-    codapCom.deleteAllAttributes(device, ui.populateContextsList(caseVariables, view, codapCom));
+    // we used to delete all attributes, and recreate them if we were a collector.
+    // we don't do that any more because it seems to take a very long time, and the request
+    // can sometimes timeout.
+    // codapCom.deleteAllAttributes(device, ui.populateContextsList(caseVariables, view, codapCom));
     codapCom.logAction("clearData:");
   }
 

--- a/TP-Sampler/src/codap-com.js
+++ b/TP-Sampler/src/codap-com.js
@@ -179,6 +179,7 @@ define([
         });
       },
 
+      // not used any more, kept for record-keeping
       deleteAllAttributes: function(device, populateContextsList) {
         var _this = this;
         codapInterface.sendRequest( {

--- a/TP-Sampler/src/codap-com.js
+++ b/TP-Sampler/src/codap-com.js
@@ -244,17 +244,12 @@ define([
             if (results.success) {
               caseVariables = [];
 
-              var count = results.values,
-                  reqs = [];
-              for (var i = 0; i < count; i++) {
-                reqs.push({
-                  action: 'get',
-                  resource: _this.collectionResourceName + '.caseByIndex['+i+']'
-                });
-              }
-              codapInterface.sendRequest(reqs).then(function(results) {
-                results.forEach(function(res) {
-                  caseVariables.push(res.values['case'].values);
+              codapInterface.sendRequest({
+                action: 'get',
+                resource: _this.collectionResourceName + '.allCases'
+              }).then(function(results) {
+                caseVariables = results.values.cases.map(function(_case) {
+                  return _case.case.values;
                 });
                 resolve(caseVariables);
              });

--- a/TP-Sampler/src/codap-com.js
+++ b/TP-Sampler/src/codap-com.js
@@ -262,15 +262,19 @@ define([
           }
 
           function addAttributes() {
+            const requests = []
             _this.collectionAttributes.forEach(function (attr) {
               if (_this.drawAttributes.indexOf(attr) < 0) {
-                codapInterface.sendRequest({
+                requests.push({
                   action: 'create',
                   resource: getTargetDataSetPhrase() + '.collection[items].attribute',
                   values: [attr]
                 });
               }
             });
+
+
+            codapInterface.sendRequest(requests);
           }
 
           function setCollection (result) {

--- a/TP-Sampler/src/view.js
+++ b/TP-Sampler/src/view.js
@@ -306,17 +306,17 @@ define(function() {
       }
     },
 
-    animateSelectNextVariable: function (selection, draw, selectionMadeCallback) {
+    animateSelectNextVariable: function (selection, draw, selectionMadeCallback, allSelectionsMadeCallback) {
       if (!this.isRunning()) return;
 
       if (device === "mixer" || device === "collector") {
-        this.animateMixerSelection(selection, draw, selectionMadeCallback);
+        this.animateMixerSelection(selection, draw, selectionMadeCallback, allSelectionsMadeCallback);
       } else {
-        this.animateSpinnerSelection(selection, draw, selectionMadeCallback);
+        this.animateSpinnerSelection(selection, draw, selectionMadeCallback, allSelectionsMadeCallback);
       }
     },
 
-    moveLetterToSlot: function (slot, sourceLetter, insertBeforeElement, initialTrans, selectionMadeCallback) {
+    moveLetterToSlot: function (slot, sourceLetter, insertBeforeElement, initialTrans, selectionMadeCallback, allSelectionsMadeCallback) {
       var _this = this;
       if (!this.isRunning()) return;
       // move variable to slot
@@ -326,6 +326,7 @@ define(function() {
         clipPath: "none",
         dx: 0
       });
+      window.samples = samples;
       samples.push(letter);
       insertBeforeElement.before(letter);
 
@@ -342,14 +343,16 @@ define(function() {
 
       var speed = this.getProps().speed;
 
-      letter.animate({transform: matrix, fontSize: size, dy: size/4}, 200/speed);
-
-      if (slot === Math.floor(sampleSize)-1) {
-        _this.pushAllLettersOut(selectionMadeCallback);
-      }
+      letter.animate({transform: matrix, fontSize: size, dy: size/4}, 200/speed, function() {
+        if (slot === Math.floor(sampleSize)-1) {
+          _this.pushAllLettersOut(selectionMadeCallback, allSelectionsMadeCallback);
+        } else {
+          selectionMadeCallback();
+        }
+      });
     },
 
-    pushAllLettersOut: function(selectionMadeCallback) {
+    pushAllLettersOut: function(selectionMadeCallback, allSelectionsMadeCallback) {
       var _this = this;
       setTimeout(pushLettersOut, 300/speed);
       setTimeout(returnSlots, 600/speed);
@@ -359,6 +362,7 @@ define(function() {
           setTimeout(selectionMade, 200);
         } else {
           selectionMadeCallback();
+          allSelectionsMadeCallback();
         }
       }
 
@@ -391,6 +395,7 @@ define(function() {
           setTimeout(returnSlots, 200);
           return;
         }
+        samples.forEach(letter => letter.remove());
         samples = [];
         var speed = _this.getProps().speed,
             i, ii;
@@ -406,9 +411,9 @@ define(function() {
       }
     },
 
-    animateMixerSelection: function (selection, draw, selectionMadeCallback) {
+    animateMixerSelection: function (selection, draw, selectionMadeCallback, allSelectionsMadeCallback) {
       if (isNaN(selection)) {   // EMPTY selection
-        this.pushAllLettersOut(selectionMadeCallback);
+        this.pushAllLettersOut(selectionMadeCallback, allSelectionsMadeCallback);
         return;
       }
       var _this = this,
@@ -432,7 +437,7 @@ define(function() {
           if (!withReplacement) {
             ball.attr({ visibility: "hidden"});
           }
-          _this.moveLetterToSlot(draw, variable, ball, trans, selectionMadeCallback);
+          _this.moveLetterToSlot(draw, variable, ball, trans, selectionMadeCallback, allSelectionsMadeCallback);
           ball.beingSelected = false;
           if (hidden) {
             setTimeout(function() {
@@ -445,7 +450,7 @@ define(function() {
         if (!withReplacement) {
           ball.attr({ visibility: "hidden"});
         }
-        _this.moveLetterToSlot(draw, variable, ball, trans, selectionMadeCallback);
+        _this.moveLetterToSlot(draw, variable, ball, trans, selectionMadeCallback, allSelectionsMadeCallback);
       }
 
     },
@@ -672,7 +677,7 @@ define(function() {
       return label;
     },
 
-    animateSpinnerSelection: function (selection, draw, selectionMadeCallback) {
+    animateSpinnerSelection: function (selection, draw, selectionMadeCallback, allSelectionsMadeCallback) {
       var _this = this;
       if (!needle) {
         // draw initial needle
@@ -704,7 +709,7 @@ define(function() {
 
       needle.animate({transform: "R"+targetAngle+","+spinnerX+","+spinnerY}, 600/speed, mina.easeinout, function() {
         var letter = wedges[selection] || wedges[0];
-        _this.moveLetterToSlot(draw, letter, letter, null, selectionMadeCallback);
+        _this.moveLetterToSlot(draw, letter, letter, null, selectionMadeCallback, allSelectionsMadeCallback);
       });
     },
 


### PR DESCRIPTION
This closes the following PT stories:

1. [Updates and bug fixes to Sampler plugin (#172795200)](https://www.pivotaltracker.com/story/show/172795200)
2. [User can change the name "value" to be something else appropriate to their model(#161064939)](https://www.pivotaltracker.com/story/show/161064939)
3. [Text in Sampler becomes garbled (#172585167)](https://www.pivotaltracker.com/story/show/172585167)

This can be tested by dragging in the gh-pages Sampler Plugin: https://concord-consortium.github.io/codap-data-interactives//TP-Sampler/index.html

**Note:** If you drag in a new sampler plugin into an document which previously contained a sampler (e.g. our big Cars document, https://codap.concord.org/releases/latest/static/dg/en/cert/index.html#shared=102928), there will already be one empty Sampler dataset, and the new plugin will create a second one. You could delete the other dataset before dragging in the new plugin (and/or do a test with bother versions).

**Technical notes:**

The first four commits are for story 1. There are some small speed improvements to how certain commands are batched, but the main change is that we no longer delete all the attributes when we clear the table.

The next three changes are for story 2. After creating the attributes in our new dataset, we get the attribute IDs, and then monitor the dataset for attribute changes. We save any updates in the interactive, so this will still work the next time a user loads the document.

If a user has already created a dataset with the old version and the plugin loads the newer version, it will attempt to find the existing attributes to get their IDs. If a user had already changed the attribute names, we won't be able to monitor them. At that point, the user should pull in a new Sampler plugin, which will create a new dataset.

The final change fixes story 3, and ensure we correctly wait for letters to reach the pushers before pushing out, and wait for them to come back before sending any new letters.