### PR TITLE
Sonification fix MicroRhythm (WIP)

### DIFF
--- a/Sonification/MicroRhythm/SinusoidalGrains.csd
+++ b/Sonification/MicroRhythm/SinusoidalGrains.csd
@@ -13,7 +13,7 @@ giverbchL = 1
 giverbchR = 2
 turnon "VERB"
 
-gkfreq init 0
+gkfreq init 1
 gktrig init 0
 turnon "MASTER"
 


### PR DESCRIPTION
This PR aims to fix the audio glitch in MicroRhythm when selecting multiple voices played at the similar time and pitch, causing some sort of DSP overflow in Csound.

TODO:
- Toggling Play switch to stop and restart does not reset the voice scheduler properly, likely creating a one loop of silence.
- Play once button