### PR TITLE
Context title not name

### DIFF
--- a/Sonification/MicroRhythm/app.js
+++ b/Sonification/MicroRhythm/app.js
@@ -817,6 +817,9 @@ const app = new Vue({
                         }
                     });
             }
+        },
+        getContextTitle(contextName) {
+          return helper.getContextTitle(contextName);
         }
     },
     mounted() {

--- a/Sonification/MicroRhythm/app.js
+++ b/Sonification/MicroRhythm/app.js
@@ -185,7 +185,7 @@ const app = new Vue({
                 value: this.state.playbackSpeed
             });
 
-            this.speedSlider.on('release', (v) => {
+            this.speedSlider.on('release', (/*v*/) => {
                 this.state.playbackSpeed = this.speedSlider._value.value;
 
                 if (this.csoundReady) {
@@ -430,13 +430,15 @@ const app = new Vue({
             }
 
             if (this.state.focusedContext) {
-                this.attributes = helper.getAttributesForContext(this.state.focusedContext);
-                this.reselectCases();
-                kAttributeMappedProperties.forEach(p => {
-                    if (this[p + 'AttrRange']) {
-                        this.processMappedAttribute(p);
-                    }
-                })
+                helper.getAttributeNamesForContext(this.state.focusedContext).then((attrs) => {
+                    this.attributes = attrs;
+                    this.reselectCases();
+                    kAttributeMappedProperties.forEach(p => {
+                        if (this[p + 'AttrRange']) {
+                            this.processMappedAttribute(p);
+                        }
+                    })
+                });
             }
         },
         onGetGlobals() {
@@ -754,6 +756,12 @@ const app = new Vue({
                     }
                 } else if (contextName === DATAMOVES_CONTROLS_DATA.name) {
                     helper.queryDataForContext(contextName).then();
+                } else if (operation === 'updateDataContext') {
+                    helper.queryContextList()
+                        .then(() => {this.contexts = helper.getContexts();});
+                } else if (operation === 'updateAttributes') {
+                    this.resetPlay();
+                    this.onGetData();
                 } else {
                     if (operation === 'selectCases') {
                         if (contextName === this.state.focusedContext) {

--- a/Sonification/MicroRhythm/index.html
+++ b/Sonification/MicroRhythm/index.html
@@ -56,7 +56,9 @@
             <label>
                 <select v-model="state.focusedContext" v-on:change="onContextFocused" id="contextDropArea">
                     <option disabled value="" hidden>Select context</option>
-                    <option v-for="context in contexts">{{context}}</option>
+                    <option v-for="context in contexts" :value="context">
+                        {{getContextTitle(context)}}
+                    </option>
                 </select>
             </label>
         </div>

--- a/Sonification/lib/CodapPluginHelper.js
+++ b/Sonification/lib/CodapPluginHelper.js
@@ -542,8 +542,25 @@ class CodapPluginHelper {
         return (this.data && Object.keys(this.data).length) ? this.data[context][collection].map(c => c.values[attribute]) : null;
     }
 
-    getAttributesForContext(context) {
-        return this.itemAttributes ? this.itemAttributes[context] : null;
+    getAttributesForContext(contextName) {
+        return this.itemAttributes ? this.itemAttributes[contextName] : null;
+    }
+
+    getAttributeNamesForContext(contextName) {
+        return this.codapInterface.sendRequest({action: 'get', resource: `dataContext[${contextName}]`})
+            .then((result) => {
+                if (result.success) {
+                    let collections = result.values.collections;
+                    let attributeNames = [];
+                    collections && collections.forEach((col) => {
+                           col.attrs.forEach((attr) => {attributeNames.push(attr.name)});
+                        }
+                    )
+                    return Promise.resolve(attributeNames);
+                } else {
+                    return Promise.reject('failure');
+                }
+            })
     }
 
     getItemsForContext(context) {

--- a/Sonification/lib/CodapPluginHelper.js
+++ b/Sonification/lib/CodapPluginHelper.js
@@ -10,6 +10,7 @@ class CodapPluginHelper {
 
         // TODO: collections are unordered.
         this.data = null;
+        this.contextTitles = null;
         this.structure = null;
 
         this.globals = null;
@@ -201,6 +202,7 @@ class CodapPluginHelper {
             } else {
                 this.queryInProgress = true;
                 this.data = {};
+                this.contextTitles = {};
                 this.queryContextList().then(() => {
                     this.queryCollectionList().then(() => {
                         this.queryAllCases().then(() => {
@@ -252,6 +254,7 @@ class CodapPluginHelper {
         }).then(result => {
             result.values.forEach(context => {
                 this.data[context.name] = {};
+                this.contextTitles[context.name] = context.title || context.name;
             });
         });
     }
@@ -545,6 +548,10 @@ class CodapPluginHelper {
 
     getItemsForContext(context) {
         return this.items && this.items[context];
+    }
+
+    getContextTitle(context) {
+        return this.contextTitles && this.contextTitles[context] ;
     }
 
     getAttrValuesForContext(context, attribute) {


### PR DESCRIPTION
This PR fixes two small issues:
* The names of data contexts were displayed in the UI. The title should be displayed. Names are permanent. Titles can be changed by the user and are visible elsewhere in CODAP.
* The plugin was not responding to changes in the data context metadata, either the context name or the attribute names.