### PR TITLE
Trim whitespace from item name. (#185233970)

### DIFF
--- a/TP-Sampler/src/view.js
+++ b/TP-Sampler/src/view.js
@@ -753,7 +753,7 @@ View.prototype = {
 
   setVariableName: function () {
     if (editingVariable !== false) {
-      var newName = variableNameInput.value;
+      var newName = variableNameInput.value.trim();
       if (!newName) newName = "_";
       if (Array.isArray(editingVariable)) {
         for (var i = 0, ii = editingVariable.length; i < ii; i++) {


### PR DESCRIPTION
Small fix to address issue of white space causing new variables to be created unnecessarily.