### PR TITLE
Run number resets to 0 when data is cleared. (PT-185608370)

### DIFF
--- a/TP-Sampler/src/app.js
+++ b/TP-Sampler/src/app.js
@@ -318,6 +318,7 @@ function stopButtonPressed() {
 function resetButtonPressed() {
   this.blur();
   experimentNumber = 0;
+  mostRecentRunNumber = 0;
   codapCom.deleteAll();
   // we used to delete all attributes, and recreate them if we were a collector.
   // we don't do that any more because it seems to take a very long time, and the request


### PR DESCRIPTION
This PR fixes the following bug:

- _Currently pressing **CLEAR DATA** causes the next sample number to continue from wherever it was previously and the next experiment number to be 1. The desired behavior is that both start over at 1._