### PR TITLE
Remove some of the measures options. (PT-186625146)

### DIFF
--- a/TP-Sampler/index.html
+++ b/TP-Sampler/index.html
@@ -80,12 +80,12 @@
             <option id="sum" value="sum" data-text="DG.plugin.Sampler.sum"></option>
             <option id="mean" value="mean" data-text="DG.plugin.Sampler.mean"></option>
             <option id="median" value="median" data-text="DG.plugin.Sampler.median"></option>
-            <option id="conditional_sum" value="conditional_sum" data-text="DG.plugin.Sampler.conditional_sum"></option>
+            <!-- <option id="conditional_sum" value="conditional_sum" data-text="DG.plugin.Sampler.conditional_sum"></option> -->
             <option id="conditional_percentage" value="conditional_percentage" data-text="DG.plugin.Sampler.conditional_percentage"></option>
-            <option id="conditional_mean" value="conditional_mean" data-text="DG.plugin.Sampler.conditional_mean"></option>
-            <option id="conditional_median" value="conditional_median" data-text="DG.plugin.Sampler.conditional_median"></option>
-            <option id="difference_of_means" value="difference_of_means" data-text="DG.plugin.Sampler.difference_of_means"></option>
-            <option id="difference_of_medians" value="difference_of_medians" data-text="DG.plugin.Sampler.difference_of_medians"></option>
+            <!-- <option id="conditional_mean" value="conditional_mean" data-text="DG.plugin.Sampler.conditional_mean"></option> -->
+            <!-- <option id="conditional_median" value="conditional_median" data-text="DG.plugin.Sampler.conditional_median"></option> -->
+            <!-- <option id="difference_of_means" value="difference_of_means" data-text="DG.plugin.Sampler.difference_of_means"></option> -->
+            <!-- <option id="difference_of_medians" value="difference_of_medians" data-text="DG.plugin.Sampler.difference_of_medians"></option> -->
           </select>
         </div>
         <div id="measure-name-container">

--- a/TP-Sampler/src/codap-com.js
+++ b/TP-Sampler/src/codap-com.js
@@ -88,7 +88,7 @@ CodapCom.prototype = {
     return codapInterface.init({
       name: this.localeMgr.tr('DG.plugin.Sampler.title'),
       title: this.localeMgr.tr('DG.plugin.Sampler.title'),
-      version: 'v0.39 (#' + window.codapPluginConfig.buildNumber + ')',
+      version: 'v0.40 (#' + window.codapPluginConfig.buildNumber + ')',
       preventDataContextReorg: false,
       stateHandler: this.loadStateFunc
     }).then( function( iInitialState) {


### PR DESCRIPTION
Limit select options to:
- Sum: sum(Age)
- Mean: mean(Age)
- Median: median(Age)
- Count: count(Sex = “male”)
- Percent: 100 * count(Sex = “male”)/count()

The other options are only commented out for now because it seems likely that they will be added back in at a future date.