### PR TITLE
186395230 fix delete variable

### DIFF
--- a/TP-Sampler/src/view.js
+++ b/TP-Sampler/src/view.js
@@ -886,8 +886,8 @@ View.prototype = {
       const clickedPct = e.target.classList?.contains("percent");
       const elsToCheck = clickedWedge ? wedgeEls : clickedLabel ? nameLabels : clickedPct ? pctLabels : null;
       const isEditing = () => {
-        const isPercentInputVisible = variablePercentageInput.offsetWidth > 0 ||               variablePercentageInput.offsetHeight > 0;
-        const isNameInputVisible = variableNameInput.offsetWidth > 0 ||               variableNameInput.offsetHeight > 0;
+        const isPercentInputVisible = variablePercentageInput.offsetWidth > 0 || variablePercentageInput.offsetHeight > 0;
+        const isNameInputVisible = variableNameInput.offsetWidth > 0 || variableNameInput.offsetHeight > 0;
         return isPercentInputVisible || isNameInputVisible
       };
 
@@ -1265,7 +1265,9 @@ View.prototype = {
       const selectedElements = document.getElementsByClassName(selectedVariable);
 
       for (let i = 0; i < selectedElements.length; i++) {
-        selectedElements[i].remove();
+        if (selectedElements[i].nodeName !== "INPUT") {
+          selectedElements[i].remove();
+        }
       }
 
       // update variables and unique variables
@@ -1274,7 +1276,6 @@ View.prototype = {
       variables.push(...newArray);
       uniqueVariables.splice(0, variables.length);
       uniqueVariables = [...new Set(variables)];
-
       editingVariable = false;
       _this.render();
     }


### PR DESCRIPTION
In the spinner, when we delete a variable, we delete all elements with the class name of the that variable, including the input nodes. But we don't generate multiple input nodes for every variable so when we delete a variable, it also deletes the input nodes from the DOM.
This adds logic so we don't delete the input nodes.