### PR TITLE
188045959 fix translated legacy sampler

### DIFF
--- a/Importer/modules/strings.json
+++ b/Importer/modules/strings.json
@@ -1029,7 +1029,7 @@
     "DG.plugin.Transformers.title": "Dönüştürücüler",
     "DG.plugin.Transformers.description": "Bu eklentide sunulan birtakım araçlar yardımıyla veri setlerinde dönüşümler yapılabilir.",
     "DG.plugin.Sampler.tab.measures": "Ölçümler",
-    "DG.plugin.Sampler.measures.instructions": "Aşağıdaki şablonu kullanarak her örneklem için ortak ölçümleri hesapla.",
+    "DG.plugin.Sampler.measures.instructions": "Aşağıda verilen seçenekleri kullanarak örnekleminiz için ortak ölçümler atayabilirsiniz.",
     "DG.plugin.Sampler.measures.select-measure": "Ölçüm seç: ",
     "DG.plugin.Sampler.measures.add-measure": "Ölçüm Ekle",
     "DG.plugin.Sampler.measures.mean": "Ortalama",
@@ -1058,6 +1058,7 @@
     "DG.plugin.Sampler.measures.percent-formula-pt-2": " / sayı()",
     "DG.plugin.Sampler.measures.name-label": "Ölçümü isimlendir: ",
     "DG.plugin.Testimate.name": "İstatistiksel sınayıcı",
-    "DG.plugin.Testimate.description": "Bu eklentide klasik çıkarımsal yöntemleri kullanarak hipotezler test edebilirsiniz."
+    "DG.plugin.Testimate.description": "Bu eklentide klasik çıkarımsal yöntemler kullanılarak hipotezler test edilebilir.",
+    "DG.plugin.PurpleAir.title": "Mor Hava"
   }
 }

--- a/TP-Sampler/src/app.js
+++ b/TP-Sampler/src/app.js
@@ -14,7 +14,7 @@ var s = Snap("#model svg"),
       variables: ["a", "b", "a"],
       device: "mixer",
       withReplacement: true,
-      deviceName: "output"
+      deviceName: "DG.plugin.Sampler.dataset.attr-value"
     },
 
     dataSetName,
@@ -73,7 +73,8 @@ function getInteractiveState() {
       previousExperimentDescription: previousExperimentDescription,
       previousSampleSize: previousSampleSize,
       attrNames: codapCom.attrNames,
-      attrIds: codapCom.attrIds
+      attrIds: codapCom.attrIds,
+      collectionIds: codapCom.collectionIds
     }
   };
 }
@@ -93,7 +94,7 @@ function loadInteractiveState(state) {
     sampleSize = state.draw || sampleSize;
     numRuns = state.repeat || numRuns;
     speed = state.speed || speed;
-    deviceName = state.deviceName || deviceName;
+    deviceName = state.deviceName || localeMgr.tr(deviceName);
     if (state.device) {
       switchState(null, state.device);
     }
@@ -814,6 +815,7 @@ localeMgr.init().then(() => {
 
   view = new View(getProps, isRunning, setRunning, isPaused, setup, codapCom,
       localeMgr, sortVariablesForSpinner);
+  deviceName = localeMgr.tr(deviceName);
 
   ui.appendUIHandlers(addVariable, removeVariable, addVariableSeries,
       runButtonPressed, stopButtonPressed, resetButtonPressed, switchState, setSampleSize, setNumRuns, setDeviceName, setSpeed, view,

--- a/TP-Sampler/src/app.js
+++ b/TP-Sampler/src/app.js
@@ -55,6 +55,7 @@ var s = Snap("#model svg"),
     view;
 
 function getInteractiveState() {
+  console.log("***** getInteractiveState");
   return {
     success: true,
     values: {
@@ -81,6 +82,7 @@ function getInteractiveState() {
 
 function loadInteractiveState(state) {
   if (state) {
+    console.log("***** state", state);
     dataSetName = state.dataSetName;
     previousExperimentDescription = state.previousExperimentDescription;
     previousSampleSize = state.previousSampleSize;
@@ -109,11 +111,16 @@ function loadInteractiveState(state) {
       codapCom.attrNames = state.attrNames;
       codapCom.attrIds = state.attrIds;
     }
+    if (state.collectionIds) {
+      console.log("***** state.collectionIds", state.collectionIds);
+      codapCom.collectionIds = state.collectionIds;
+    }
   }
   view.render();
 }
 
 export function updateDeviceName (name) {
+  console.log("***** updateDeviceName: ", name);
   deviceName = name;
   ui.updateUIDeviceName(name);
 };
@@ -382,13 +389,22 @@ function run() {
           });
           ix ++;
         }
-        codapCom.addMultipleSamplesToCODAP(samples, isCollector, deviceName);
+        codapCom.findOrCreateDataContext(deviceName).then(function() {
+          codapCom.addMultipleSamplesToCODAP(samples, isCollector, deviceName);
 
-        if (currRunNumber >= sequence.length) {
-          setup();
-          return;
-        }
-        if (running) setTimeout(addValuesToCODAPNoDelay, 0);
+          if (currRunNumber >= sequence.length) {
+            setup();
+            return;
+          }
+          if (running) setTimeout(addValuesToCODAPNoDelay, 0);
+        });
+        // codapCom.addMultipleSamplesToCODAP(samples, isCollector, deviceName);
+
+        // if (currRunNumber >= sequence.length) {
+        //   setup();
+        //   return;
+        // }
+        // if (running) setTimeout(addValuesToCODAPNoDelay, 0);
       } else {
         selectNext();
       }
@@ -488,7 +504,7 @@ function run() {
       tReplacement
     ])
   }
-
+console.log("***** experimentNumber: ", experimentNumber);
   if( experimentNumber === 0 || tDescription + tStringifiedVariables !== previousExperimentDescription ||
       (previousSampleSize !== null && previousSampleSize !== tSampleSize)) {
     experimentNumber++;

--- a/TP-Sampler/src/lib/CodapInterface.js
+++ b/TP-Sampler/src/lib/CodapInterface.js
@@ -214,6 +214,7 @@ var codapInterface = {
         var success = resp && resp[1] && resp[1].success;
         var receivedFrame = success && resp[1].values;
         var savedState = receivedFrame && receivedFrame.savedState;
+        console.log("***** in codapinterface savedState", savedState);
         this_.updateInteractiveState(savedState);
         if (success) {
           // deprecated way of conveying state
@@ -259,6 +260,8 @@ var codapInterface = {
 
       if (!config.customInteractiveStateHandler) {
         this.on('get', 'interactiveState', function () {
+          const state = this.getInteractiveState();
+          console.log("***** in codapinterface state", state);
           return ({success: true, values: this.getInteractiveState()});
         }.bind(this));
       }

--- a/TP-Sampler/src/strings.json
+++ b/TP-Sampler/src/strings.json
@@ -1029,7 +1029,7 @@
     "DG.plugin.Transformers.title": "Dönüştürücüler",
     "DG.plugin.Transformers.description": "Bu eklentide sunulan birtakım araçlar yardımıyla veri setlerinde dönüşümler yapılabilir.",
     "DG.plugin.Sampler.tab.measures": "Ölçümler",
-    "DG.plugin.Sampler.measures.instructions": "Aşağıdaki şablonu kullanarak her örneklem için ortak ölçümleri hesapla.",
+    "DG.plugin.Sampler.measures.instructions": "Aşağıda verilen seçenekleri kullanarak örnekleminiz için ortak ölçümler atayabilirsiniz.",
     "DG.plugin.Sampler.measures.select-measure": "Ölçüm seç: ",
     "DG.plugin.Sampler.measures.add-measure": "Ölçüm Ekle",
     "DG.plugin.Sampler.measures.mean": "Ortalama",
@@ -1058,6 +1058,7 @@
     "DG.plugin.Sampler.measures.percent-formula-pt-2": " / sayı()",
     "DG.plugin.Sampler.measures.name-label": "Ölçümü isimlendir: ",
     "DG.plugin.Testimate.name": "İstatistiksel sınayıcı",
-    "DG.plugin.Testimate.description": "Bu eklentide klasik çıkarımsal yöntemleri kullanarak hipotezler test edebilirsiniz."
+    "DG.plugin.Testimate.description": "Bu eklentide klasik çıkarımsal yöntemler kullanılarak hipotezler test edilebilir.",
+    "DG.plugin.PurpleAir.title": "Mor Hava"
   }
 }

--- a/TP-Sampler/src/strings.json
+++ b/TP-Sampler/src/strings.json
@@ -173,7 +173,7 @@
     "DG.plugin.Sampler.dataset.attr-description": "description",
     "DG.plugin.Sampler.dataset.attr-sample_size": "sample_size",
     "DG.plugin.Sampler.dataset.attr-sample": "sample",
-    "DG.plugin.Sampler.dataset.attr-value": "value",
+    "DG.plugin.Sampler.dataset.attr-value": "output",
     "DG.plugin.Sampler.dataset.col-experiments": "experiments",
     "DG.plugin.Sampler.dataset.col-samples": "samples",
     "DG.plugin.Sampler.dataset.col-items": "items",


### PR DESCRIPTION
Use collection ids to create and restore collections and attributes.
Use previously translated string for "output" instead of hard coded string or using a new translation string that has not been translated.