### PR TITLE
CODAP-1418: onboarding title and reliable "make a table" detection on touch

### DIFF
--- a/onboarding/source/js/onboarding.js
+++ b/onboarding/source/js/onboarding.js
@@ -309,7 +309,7 @@ class TutorialView extends React.Component {
         handleDataContextCountChanged();
         break;
       case 'create':
-        if (iNotification.values.type === 'graph') this.handleAccomplishment('MakeGraph', !this.isAccomplished('Drag'));else if (iNotification.values.type === 'caseTable', !this.isAccomplished('Drag')) this.handleAccomplishment('MakeTable');
+        if (iNotification.values.type === 'graph') this.handleAccomplishment('MakeGraph', !this.isAccomplished('Drag'));else if (iNotification.values.type === 'table') this.handleAccomplishment('MakeTable', !this.isAccomplished('Drag'));
         break;
       case 'move':
         if (iNotification.values.type === 'DG.GraphView' || iNotification.values.type === 'DG.TableView') this.handleAccomplishment('MoveComponent');
@@ -405,11 +405,13 @@ function getStarted() {
 
   if ((!hasMouse && onboarding1) || (!onboarding1)) {
     csvToLoad = (onboarding1 ? tr("~onboarding1.mammals.file.and.table.title") : tr("~onboarding2.nhanes.file.and.table.title"));
+    var dataContextTitle = (onboarding1 ? tr("~onboarding1.mammals.table.title") : tr("~onboarding2.nhanes.table.title"));
     codapInterface.sendRequest({
       action: 'create',
       resource: 'dataContextFromURL',
       values: {
-        URL: window.location.href.replace(/\/[^\/]*$/, "") + "/resources/" + resourceDir() + csvToLoad
+        URL: window.location.href.replace(/\/[^\/]*$/, "") + "/resources/" + resourceDir() + csvToLoad,
+        title: dataContextTitle
       }
     }).then(function (iResult) {
       console.log('Created data context from URL');

--- a/onboarding/source/strings.json
+++ b/onboarding/source/strings.json
@@ -69,7 +69,9 @@
     "~onboarding2.all.success.message7": "Deselected cases so that none are selected",
     "~onboarding2.all.success.message8": "These are useful CODAP skills!",
     "~onboarding1.mammals.file.and.table.title": "mammals.csv",
-    "~onboarding2.nhanes.file.and.table.title": "nhanes.csv"
+    "~onboarding2.nhanes.file.and.table.title": "nhanes.csv",
+    "~onboarding1.mammals.table.title": "Mammals",
+    "~onboarding2.nhanes.table.title": "NHANES"
   },
   "es": {
     "~header.welcome": "Les damos la bienvenida a CODAP",
@@ -141,6 +143,8 @@
     "~onboarding2.all.success.message7": "Deseleccionar los casos para que no quede ninguno seleccionado",
     "~onboarding2.all.success.message8": "Estas son habilidades muy útiles de CODAP!",
     "~onboarding1.mammals.file.and.table.title": "mamiferos.csv",
-    "~onboarding2.nhanes.file.and.table.title": "nhanes.csv"
+    "~onboarding2.nhanes.file.and.table.title": "nhanes.csv",
+    "~onboarding1.mammals.table.title": "Mamíferos",
+    "~onboarding2.nhanes.table.title": "NHANES"
   }
 }

--- a/onboarding/target/onboarding.js
+++ b/onboarding/target/onboarding.js
@@ -309,7 +309,7 @@ class TutorialView extends React.Component {
         handleDataContextCountChanged();
         break;
       case 'create':
-        if (iNotification.values.type === 'graph') this.handleAccomplishment('MakeGraph', !this.isAccomplished('Drag'));else if (iNotification.values.type === 'caseTable', !this.isAccomplished('Drag')) this.handleAccomplishment('MakeTable');
+        if (iNotification.values.type === 'graph') this.handleAccomplishment('MakeGraph', !this.isAccomplished('Drag'));else if (iNotification.values.type === 'table') this.handleAccomplishment('MakeTable', !this.isAccomplished('Drag'));
         break;
       case 'move':
         if (iNotification.values.type === 'DG.GraphView' || iNotification.values.type === 'DG.TableView') this.handleAccomplishment('MoveComponent');
@@ -405,11 +405,13 @@ function getStarted() {
 
   if ((!hasMouse && onboarding1) || (!onboarding1)) {
     csvToLoad = (onboarding1 ? tr("~onboarding1.mammals.file.and.table.title") : tr("~onboarding2.nhanes.file.and.table.title"));
+    var dataContextTitle = (onboarding1 ? tr("~onboarding1.mammals.table.title") : tr("~onboarding2.nhanes.table.title"));
     codapInterface.sendRequest({
       action: 'create',
       resource: 'dataContextFromURL',
       values: {
-        URL: window.location.href.replace(/\/[^\/]*$/, "") + "/resources/" + resourceDir() + csvToLoad
+        URL: window.location.href.replace(/\/[^\/]*$/, "") + "/resources/" + resourceDir() + csvToLoad,
+        title: dataContextTitle
       }
     }).then(function (iResult) {
       console.log('Created data context from URL');

--- a/onboarding/target/strings.json
+++ b/onboarding/target/strings.json
@@ -69,7 +69,9 @@
     "~onboarding2.all.success.message7": "Deselected cases so that none are selected",
     "~onboarding2.all.success.message8": "These are useful CODAP skills!",
     "~onboarding1.mammals.file.and.table.title": "mammals.csv",
-    "~onboarding2.nhanes.file.and.table.title": "nhanes.csv"
+    "~onboarding2.nhanes.file.and.table.title": "nhanes.csv",
+    "~onboarding1.mammals.table.title": "Mammals",
+    "~onboarding2.nhanes.table.title": "NHANES"
   },
   "es": {
     "~header.welcome": "Les damos la bienvenida a CODAP",
@@ -141,6 +143,8 @@
     "~onboarding2.all.success.message7": "Deseleccionar los casos para que no quede ninguno seleccionado",
     "~onboarding2.all.success.message8": "Estas son habilidades muy útiles de CODAP!",
     "~onboarding1.mammals.file.and.table.title": "mamiferos.csv",
-    "~onboarding2.nhanes.file.and.table.title": "nhanes.csv"
+    "~onboarding2.nhanes.file.and.table.title": "nhanes.csv",
+    "~onboarding1.mammals.table.title": "Mamíferos",
+    "~onboarding2.nhanes.table.title": "NHANES"
   }
 }


### PR DESCRIPTION
## Summary

Companion to the v3 PR in concord-consortium/codap. Touch-device onboarding pre-loads
its dataset via `dataContextFromURL`. Now that v3 no longer auto-opens a case table for
that request:

- **Pass an explicit `title`** in the `dataContextFromURL` request so the dataset reads
  "Mammals" (and "NHANES" for onboarding2) when the student opens the table. Adds the
  title strings (en/es).
- **Fix the "make a table" detection** — the condition
  `(type === 'caseTable', !isAccomplished('Drag'))` used the comma operator, discarding
  the type check, so any non-graph component create (e.g. adding a slider) falsely
  completed the task; and `'caseTable'` was the wrong type anyway (create notifications
  carry `'table'` in both v2 and v3). Now mirrors the graph line:
  `else if (type === 'table') handleAccomplishment('MakeTable', !isAccomplished('Drag'))`.

### Dependency

Requires the companion v3 changes (the `title` handling on `dataContextFromURL`, and the
component `create` notification when opening a table). Without them, the title won't apply
and "make a table" won't complete.

### Deferred follow-up

The plugin's touch detection `hasMouse = !('ontouchstart' in window)` is brittle — it
over-reports touch on mouse-capable devices (touchscreen laptops, hybrids, some Chrome
configs), which routes them to the touch onboarding flow. Left unchanged here. A future
fix could use `window.matchMedia('(any-pointer: fine)').matches`, which maps more closely
to "has a precise pointer that can drag": finger-only iPad → false, iPad with
trackpad/Pencil → true, touchscreen laptop → true.

### Deployment

After merge, the rebuilt plugin must be synced to
`s3://codap-resources/plugins/onboarding/` (build-and-manual-copy: `npm run clean &&
npm run build` in `onboarding/`, then `aws s3 sync` + CloudFront invalidation). Merging
does not deploy it.

Relates to CODAP-1418.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
