### PR TITLE
fix(simmer): pin Blockly to v11 to restore getAllVariables()

### DIFF
--- a/eepsmedia/plugins/simmer/index.html
+++ b/eepsmedia/plugins/simmer/index.html
@@ -33,7 +33,7 @@ http://localhost/~tim/codap/static/dg/en/cert/index.html?di=https://localhost/~t
     <!--
         blockly
     -->
-    <script src="https://unpkg.com/blockly/blockly.min.js"></script>
+    <script src="https://unpkg.com/blockly@11/blockly.min.js"></script>
     <script src="src/block-defs.js"></script>
     <script src="src/block-generators.js"></script>
     <script src="src/bEvents.js"></script>


### PR DESCRIPTION
## Problem

A user reported Simmer broken in the current release:

```
Uncaught (in promise) TypeError: Blockly.getMainWorkspace(...).getAllVariables is not a function
    at Object.constructVariableNameArray (simmer.js:227)
    at Object.run (simmer.js:74)
```

## Cause

`eepsmedia/plugins/simmer/index.html` loaded an **unpinned**
`https://unpkg.com/blockly/blockly.min.js`, which always resolves to the latest
published Blockly. Blockly **v12** (May 2025) deprecated `Workspace.getAllVariables()`,
and **v13** (June 2026) removed it, so Simmer started failing at runtime.

Simmer calls `getAllVariables()` in three places:
- `src/simmer.js:144`
- `src/simmer.js:227`
- `src/block-generators.js:8`

## Fix

Pin the script tag to `blockly@11`, where `Workspace.getAllVariables()` still
exists. This is a one-line, zero-code-change fix with the lowest deploy risk.
Pinning the major version also prevents the next breaking Blockly release from
re-breaking Simmer.

## Deploy note

Simmer is served as raw source (no build step), so the deployable artifact is
this folder as-is. After merge it will be deployed directly to
`s3://codap-resources/plugins/eepsmedia/plugins/simmer/` (no V2 build involved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
